### PR TITLE
Update README instructions to clone T4 repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ experience as we tend to refactor pretty aggressively.
 - Docker which runs Postgres - _feel free to edit `.env` to remove the dependency on Docker and connect to your own_
 
 ```bash
-git clone git@github.com:tolahq/eval.git
+git clone git@github.com:tolahq/t4.git
 npm install
 cp .env.example .env # and edit if needed
 npm run db-up # starts Postgres, migrates db and adds seed data


### PR DESCRIPTION
README instructions point to a previous version of the repository name.

```
 $ git clone git@github.com:tolahq/eval.git
Cloning into 'eval'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

## Test
```
$ git clone git@github.com:tolahq/t4.git
Cloning into 't4'...
remote: Enumerating objects: 68, done.
remote: Counting objects: 100% (68/68), done.
remote: Compressing objects: 100% (57/57), done.
remote: Total 68 (delta 0), reused 68 (delta 0), pack-reused 0
Receiving objects: 100% (68/68), 202.79 KiB | 795.00 KiB/s, done.
```