### PR TITLE
some tweaks

### DIFF
--- a/src/server/routers/bill.test.ts
+++ b/src/server/routers/bill.test.ts
@@ -10,11 +10,11 @@ import { sample } from '~/utils/fake';
 const getCreditMock = () =>
   jest.spyOn(PortalPaymentService.prototype, 'credit');
 
-let creditMock: ReturnType<typeof getCreditMock>;
+let creditSpy: ReturnType<typeof getCreditMock>;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  creditMock = getCreditMock();
+  creditSpy = getCreditMock();
 });
 
 test('list posts', async () => {
@@ -50,7 +50,7 @@ test.skip('pay bill', async () => {
     amount: bill.amount,
   });
 
-  expect(creditMock).toHaveBeenCalledTimes(1);
+  expect(creditSpy).toHaveBeenCalledTimes(1);
 });
 
 test.skip('pay bill - race condition', async () => {
@@ -86,7 +86,7 @@ test.skip('pay bill - race condition', async () => {
   ]);
 
   // only 1 should succeed
-  expect(creditMock).toHaveBeenCalledTimes(1);
+  expect(creditSpy).toHaveBeenCalledTimes(1);
   expect(
     results.filter((result) => result.status === 'fulfilled'),
   ).toHaveLength(1);

--- a/src/server/routers/bill.test.ts
+++ b/src/server/routers/bill.test.ts
@@ -46,8 +46,6 @@ test.skip('pay bill', async () => {
   // pay bill
   await caller.mutation('bill.pay', {
     billId: bill.id,
-    accountId: 'something',
-    amount: bill.amount,
   });
 
   expect(creditSpy).toHaveBeenCalledTimes(1);
@@ -75,13 +73,9 @@ test.skip('pay bill - race condition', async () => {
   const results = await Promise.allSettled([
     caller.mutation('bill.pay', {
       billId: bill.id,
-      amount: bill.amount,
-      accountId: 'fake',
     }),
     caller.mutation('bill.pay', {
       billId: bill.id,
-      amount: bill.amount,
-      accountId: 'fake',
     }),
   ]);
 

--- a/src/server/routers/bill.ts
+++ b/src/server/routers/bill.ts
@@ -66,7 +66,7 @@ export const postRouter = createRouter()
     input: z.object({
       billId: z.string(),
     }),
-    async resolve() {
+    async resolve({ input }) {
       // TODO: Implement this function.
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',

--- a/src/server/routers/bill.ts
+++ b/src/server/routers/bill.ts
@@ -64,11 +64,9 @@ export const postRouter = createRouter()
   })
   .mutation('pay', {
     input: z.object({
-      amount: z.number(),
       billId: z.string(),
-      accountId: z.string(),
     }),
-    async resolve({ input }) {
+    async resolve() {
       // TODO: Implement this function.
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',

--- a/src/server/service/payment/index.ts
+++ b/src/server/service/payment/index.ts
@@ -28,7 +28,7 @@ export class PortalPaymentService {
     //
   }
 
-  async credit(opts: { accountId: string; amount: number }) {
+  async credit(opts: { vendorId: string; amount: number }) {
     return {
       id: v4(),
       amount: opts.amount,


### PR DESCRIPTION
Quick stab at hopefully removing some unnecessary pitfalls

- make mocking easier
- remove `amount`/`accountId` on procedure
- rename `accountId` -> `vendorId`